### PR TITLE
Set android workflow to track the main branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,9 +16,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v1
-      - name: set up JDK 1.8
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: Build project
         run: .github/scripts/gradlew_recursive.sh assembleDebug
       - name: Zip artifacts


### PR DESCRIPTION
The current workflow tracks the `master` branch. This move the tracking to the `main` branch that is now the defaul.

The second commit in this PR updates the workflow to use JDK 11 to support newer gradle/AGP.