### PR TITLE
Add feedback to device management app.

### DIFF
--- a/AppRestrictionSchema/Application/build.gradle
+++ b/AppRestrictionSchema/Application/build.gradle
@@ -53,4 +53,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    implementation "androidx.enterprise:enterprise-feedback:$enterprise_version"
+    // For testing enterprise feedback in isolation
+    implementation "androidx.enterprise:enterprise-feedback-testing:$enterprise_version"
 }

--- a/AppRestrictionSchema/Application/src/main/java/com/example/android/apprestrictionschema/AppRestrictionSchemaFragment.kt
+++ b/AppRestrictionSchema/Application/src/main/java/com/example/android/apprestrictionschema/AppRestrictionSchemaFragment.kt
@@ -105,6 +105,7 @@ class AppRestrictionSchemaFragment : Fragment(), View.OnClickListener {
         val entries = manager.getManifestRestrictions(
             requireActivity().applicationContext.packageName
         )
+
         for (entry in entries) {
             val key = entry.key
             Log.d(TAG, "key: $key")
@@ -137,6 +138,9 @@ class AppRestrictionSchemaFragment : Fragment(), View.OnClickListener {
         } else {
             restrictions.getBoolean(KEY_CAN_SAY_HELLO)
         }
+        activity?.let {
+            enterpriseFeedback(it.application, KEY_CAN_SAY_HELLO, "Value is $canSayHello", "$canSayHello")
+        }
         binding.sayHello.setText(
             if (canSayHello) {
                 R.string.explanation_can_say_hello_true
@@ -154,6 +158,9 @@ class AppRestrictionSchemaFragment : Fragment(), View.OnClickListener {
             } else {
                 restrictions.getString(KEY_MESSAGE)
             }
+        activity?.let {
+            enterpriseFeedback(it.application, KEY_MESSAGE, "Value is $message", "$message")
+        }
     }
 
     private fun updateNumber(entry: RestrictionEntry, restrictions: Bundle?) {

--- a/AppRestrictionSchema/Application/src/main/java/com/example/android/apprestrictionschema/EnterpriseReporter.kt
+++ b/AppRestrictionSchema/Application/src/main/java/com/example/android/apprestrictionschema/EnterpriseReporter.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.apprestrictionschema
+
+import android.content.Context
+import android.util.Log
+import androidx.enterprise.feedback.KeyedAppState
+import androidx.enterprise.feedback.KeyedAppStatesCallback
+import androidx.enterprise.feedback.KeyedAppStatesCallback.STATUS_EXCEEDED_BUFFER_ERROR
+import androidx.enterprise.feedback.KeyedAppStatesCallback.STATUS_SUCCESS
+import androidx.enterprise.feedback.KeyedAppStatesCallback.STATUS_TRANSACTION_TOO_LARGE_ERROR
+import androidx.enterprise.feedback.KeyedAppStatesCallback.STATUS_UNKNOWN_ERROR
+import androidx.enterprise.feedback.KeyedAppStatesReporter
+
+/**
+ * Sends feedback to device management apps.
+ */
+fun enterpriseFeedback(
+    context: Context,
+    key: String,
+    message: String,
+    data: String,
+    severity: Int = KeyedAppState.SEVERITY_ERROR
+) {
+    val keyedAppStatesReporter = KeyedAppStatesReporter.create(context)
+    val keyedAppStateMessage = KeyedAppState.builder()
+        .setSeverity(severity)
+        .setKey(key)
+        .setMessage(message)
+        .setData(data)
+        .build()
+    val list: MutableList<KeyedAppState> = ArrayList()
+    list.add(keyedAppStateMessage)
+    keyedAppStatesReporter.setStates(list, Callback())
+}
+
+internal class Callback : KeyedAppStatesCallback {
+    override fun onResult(state: Int, throwable: Throwable?) {
+        when (state) {
+            STATUS_SUCCESS ->
+                Log.i("ErrorReporter", "KeyedAppStatesCallback status: SUCCESS ")
+            STATUS_UNKNOWN_ERROR ->
+                Log.i("ErrorReporter", "KeyedAppStatesCallback status: UNKNOWN_ERROR ")
+            STATUS_TRANSACTION_TOO_LARGE_ERROR ->
+                Log.i("ErrorReporter", "KeyedAppStatesCallback status: TRANSACTION_TOO_LARGE_ERROR ")
+            STATUS_EXCEEDED_BUFFER_ERROR ->
+                Log.i("ErrorReporter", "KeyedAppStatesCallback status: EXCEEDED_BUFFER_ERROR ")
+            else ->
+                Log.i("ErrorReporter", "KeyedAppStatesCallback status: $state ")
+        }
+    }
+}

--- a/AppRestrictionSchema/README.md
+++ b/AppRestrictionSchema/README.md
@@ -54,9 +54,7 @@ checked by calling [RestrictionsManager.getApplicationRestrictions()][2].
 Pre-requisites
 --------------
 
-- Android SDK 28
-- Android Build Tools v28.0.3
-- Android Support Repository
+- Android Studio Dolphin | 2021.3.1
 
 Screenshots
 -------------
@@ -75,7 +73,7 @@ Support
 - Stack Overflow: http://stackoverflow.com/questions/tagged/android
 
 If you've found an error in this sample, please file an issue:
-https://github.com/android/enterprise
+https://github.com/android/enterprise-samples/issues
 
 Patches are encouraged, and may be submitted by forking this project and
 submitting a pull request through GitHub. Please see CONTRIBUTING.md for more details.

--- a/AppRestrictionSchema/build.gradle
+++ b/AppRestrictionSchema/build.gradle
@@ -16,6 +16,8 @@
 
 buildscript {
     ext.kotlin_version = '1.7.10'
+    ext.enterprise_version = "1.1.0"
+
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
Use Jetpack Enterprise to send feedback to the device management app.

TestDPC can be used to test locally the correct working of the feedback delivery.