### PR TITLE
Add write permission for copy workflow

### DIFF
--- a/.github/workflows/copy-branch.yml
+++ b/.github/workflows/copy-branch.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches: [ main ]
 
+# Add this permissions block at the workflow level
+permissions:
+  contents: write # Allows the GITHUB_TOKEN to write to the repository contents
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "copy-branch"


### PR DESCRIPTION
This fix write permission for the copy workflow as the GITHUB_TOKEN only has **Read repository contents and packages permissions**.